### PR TITLE
Avoid :uri_string.parse/1

### DIFF
--- a/lib/aws_rds_castore.ex
+++ b/lib/aws_rds_castore.ex
@@ -21,7 +21,7 @@ defmodule AwsRdsCAStore do
   @doc """
   Returns a set of `:ssl` transport options for certificate verification.
 
-  Accepts a database URI instead of hostname on OTP 21 or later.
+  Accepts an Ecto database URI or a hostname.
 
   ## Examples
 
@@ -34,7 +34,20 @@ defmodule AwsRdsCAStore do
         socket_options: maybe_ipv6
 
   """
+  def ssl_opts(url_or_hostname) when is_list(url_or_hostname) do
+    ssl_opts(List.to_string(url_or_hostname))
+  end
+
   def ssl_opts(url_or_hostname) do
-    :aws_rds_castore.ssl_opts(url_or_hostname)
+    hostname =
+      case URI.parse(url_or_hostname) do
+        %URI{scheme: nil} ->
+          url_or_hostname
+
+        %URI{host: host} ->
+          host
+      end
+
+    :aws_rds_castore.ssl_opts(hostname)
   end
 end

--- a/src/aws_rds_castore.erl
+++ b/src/aws_rds_castore.erl
@@ -11,28 +11,13 @@ file_path() ->
     list_to_binary(filename:join(PrivDir, "global-bundle.pem")).
 
 %% Returns a set of `:ssl` transport options for certificate verification.
-ssl_opts(UrlOrHostname) when is_binary(UrlOrHostname) ->
-    ssl_opts(binary_to_list(UrlOrHostname));
+ssl_opts(Hostname) when is_binary(Hostname) ->
+    ssl_opts(binary_to_list(Hostname));
 
-ssl_opts(UrlOrHostname) ->
-    % Accepts a database URI if uri_string module is available, so from OTP 21
-    ServerName =
-        case code:ensure_loaded(uri_string) of
-            {module,uri_string} ->
-                case uri_string:parse(UrlOrHostname) of
-                    #{host := Hostname} ->
-                        Hostname;
-                    _ ->
-                        UrlOrHostname
-                end;
-
-            _ ->
-                UrlOrHostname
-        end,
-
+ssl_opts(Hostname) ->
     [
       {verify, verify_peer},
       {cacertfile, file_path()},
       {depth, 10},
-      {server_name_indication, ServerName}
+      {server_name_indication, Hostname}
     ].

--- a/test/aws_rds_castore_test.exs
+++ b/test/aws_rds_castore_test.exs
@@ -36,7 +36,9 @@ defmodule AwsRdsCAStoreTest do
     end
 
     test "with url with special characters" do
-      ssl_opts = AwsRdsCAStore.ssl_opts("postgres://postgres:secret[]123!{}@some.host.name/my_app_db")
+      ssl_opts =
+        AwsRdsCAStore.ssl_opts("postgres://postgres:secret[]123!{}@some.host.name/my_app_db")
+
       assert :verify_peer = ssl_opts[:verify]
       assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
       assert 'some.host.name' = ssl_opts[:server_name_indication]

--- a/test/aws_rds_castore_test.exs
+++ b/test/aws_rds_castore_test.exs
@@ -21,20 +21,45 @@ defmodule AwsRdsCAStoreTest do
       assert 'some.host.name' = ssl_opts[:server_name_indication]
     end
 
-    if :erlang.system_info(:otp_release) |> List.to_integer() >= 21 do
-      test "with url" do
-        ssl_opts = AwsRdsCAStore.ssl_opts("postgres://postgres:postgres@some.host.name/my_app_db")
-        assert :verify_peer = ssl_opts[:verify]
-        assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
-        assert 'some.host.name' = ssl_opts[:server_name_indication]
-      end
+    test "with url" do
+      ssl_opts = AwsRdsCAStore.ssl_opts("postgres://postgres:postgres@some.host.name/my_app_db")
+      assert :verify_peer = ssl_opts[:verify]
+      assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
+      assert 'some.host.name' = ssl_opts[:server_name_indication]
+    end
 
-      test "with url (charlist)" do
-        ssl_opts = AwsRdsCAStore.ssl_opts('postgres://postgres:postgres@some.host.name/my_app_db')
-        assert :verify_peer = ssl_opts[:verify]
-        assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
-        assert 'some.host.name' = ssl_opts[:server_name_indication]
-      end
+    test "with url (charlist)" do
+      ssl_opts = AwsRdsCAStore.ssl_opts('postgres://postgres:postgres@some.host.name/my_app_db')
+      assert :verify_peer = ssl_opts[:verify]
+      assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
+      assert 'some.host.name' = ssl_opts[:server_name_indication]
+    end
+
+    test "with url with special characters" do
+      ssl_opts = AwsRdsCAStore.ssl_opts("postgres://postgres:secret[]123!{}@some.host.name/my_app_db")
+      assert :verify_peer = ssl_opts[:verify]
+      assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
+      assert 'some.host.name' = ssl_opts[:server_name_indication]
+    end
+  end
+
+  describe "Erlang API" do
+    test "file_path/0" do
+      assert String.ends_with?(:aws_rds_castore.file_path(), "/priv/global-bundle.pem")
+    end
+
+    test "ssl_opts/1 (charlist)" do
+      ssl_opts = :aws_rds_castore.ssl_opts('some.host.name')
+      assert :verify_peer = ssl_opts[:verify]
+      assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
+      assert 'some.host.name' = ssl_opts[:server_name_indication]
+    end
+
+    test "ssl_opts/1 (binary)" do
+      ssl_opts = :aws_rds_castore.ssl_opts("some.host.name")
+      assert :verify_peer = ssl_opts[:verify]
+      assert String.ends_with?(ssl_opts[:cacertfile], "/priv/global-bundle.pem")
+      assert 'some.host.name' = ssl_opts[:server_name_indication]
     end
   end
 end


### PR DESCRIPTION
`:uri_string.parse/1` has trouble with URIs containing special characters in password, much more than Elixir's `URI` module. Since database URIs are mostly an Elixir thing, it's probably best to make the Erlang API accept only hostnames, and go back to using `URI.parse/1` on the Elixir side.