### PR TITLE
add Mix Task to Hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AwsRdsCAStore.MixProject do
   use Mix.Project
 
-  @version "1.2.0"
+  @version "1.2.1-dev"
   @repo_url "https://github.com/voltone/aws_rds_castore"
 
   def project do
@@ -44,7 +44,7 @@ defmodule AwsRdsCAStore.MixProject do
   defp package do
     [
       files: [
-        "lib/aws_rds_castore.ex",
+        "lib",
         "priv",
         "src",
         "mix.exs",


### PR DESCRIPTION
The Mix Task `aws_rds_ca_store.certdata` is not included in the latest release:

```console
$ mix hex.package fetch aws_rds_castore --unpack
aws_rds_castore v1.2.0 extracted to /private/tmp/aws_rds_castore-1.2.0
$ tree aws_rds_castore-1.2.0/
aws_rds_castore-1.2.0/
├── README.md
├── hex_metadata.config
├── lib
│   └── aws_rds_castore.ex
├── mix.exs
├── priv
│   └── global-bundle.pem
├── rebar.config
└── src
    ├── aws_rds_castore.app.src
    └── aws_rds_castore.erl

4 directories, 8 files
```

After this minor change, the Mix Task is included:

```console
```console
$ mix hex.build --unpack
Building aws_rds_castore 1.2.1-dev
  App: aws_rds_castore
  Name: aws_rds_castore
  Files:
    lib
    lib/aws_rds_castore.ex
    lib/mix
    lib/mix/tasks
    lib/mix/tasks/aws_rds_castore
    lib/mix/tasks/aws_rds_castore/certdata.ex
    priv
    priv/global-bundle.pem
    src
    src/aws_rds_castore.erl
    src/aws_rds_castore.app.src
    mix.exs
    rebar.config
    README.md
  Version: 1.2.1-dev
  Build tools: mix, rebar3
  Description: AWS RDS CA certificate store.
  Licenses: Apache-2.0
  Links:
    GitHub: https://github.com/voltone/aws_rds_castore
  Elixir: ~> 1.0
Saved to aws_rds_castore-1.2.1-dev
$ tree aws_rds_castore-1.2.1-dev/
aws_rds_castore-1.2.1-dev/
├── README.md
├── hex_metadata.config
├── lib
│   ├── aws_rds_castore.ex
│   └── mix
│       └── tasks
│           └── aws_rds_castore
│               └── certdata.ex
├── mix.exs
├── priv
│   └── global-bundle.pem
├── rebar.config
└── src
    ├── aws_rds_castore.app.src
    └── aws_rds_castore.erl

7 directories, 9 files
```
