### PR TITLE
Always require public_key

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,8 +32,7 @@ defmodule AwsRdsCAStore.MixProject do
     ]
   end
 
-  defp extra_applications(:prod), do: [:logger]
-  defp extra_applications(_env), do: [:public_key] ++ extra_applications(:prod)
+  defp extra_applications(_env), do: [:public_key]
 
   defp deps do
     [


### PR DESCRIPTION
We now ship the Mix task that checks for updates, in case someone wants to run that locally (see #8), which means we now depend on the `public_key` application also in `:prod` environment.

Closes #12 